### PR TITLE
Fix bug serializing params and exception reporting

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,16 @@
+# https://github.com/reviewdog/action-rubocop
+name: Rubocop
+on: [pull_request]
+jobs:
+  rubocop:
+    name: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Rubocop linter
+        uses: reviewdog/action-rubocop@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review # Optional. Default: github-pr-check
+          level: error # Optional. Default: error

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,0 @@
-ruby:
-  enabled: true
-  config_file: .rubocop.yml

--- a/lib/carto/common/action_controller_log_subscriber.rb
+++ b/lib/carto/common/action_controller_log_subscriber.rb
@@ -42,7 +42,7 @@ module Carto
         end
         log_entry.merge!(status: status, status_text: Rack::Utils::HTTP_STATUS_CODES[status])
 
-        exception.present? ? error(log_entry) : info(log_entry)
+        exception.present? || status.to_s.match?(/5\d\d/) ? error(log_entry) : info(log_entry)
       end
 
       def halted_callback(event)

--- a/lib/carto/common/rack_logger_middleware.rb
+++ b/lib/carto/common/rack_logger_middleware.rb
@@ -6,6 +6,15 @@ module Carto
   module Common
     class RackLoggerMiddleware < ::Rails::Rack::Logger
 
+      # Complete with parameters that can be safely logged, as it is
+      # safer to don't log anything by default.
+      LOGGABLE_PARAMS = %w(
+        id
+        username
+        created_at
+        updated_at
+      )
+
       private
 
       def started_request_message(request)
@@ -26,8 +35,8 @@ module Carto
         hash.each do |key, value|
           if value.is_a?(Hash)
             deep_obfuscate_values(value)
-          elsif key.match?(/password|auth|token|crypt|secret/i)
-            hash[key] = '[FILTERED]'
+          elsif value.is_a?(String)
+            hash[key] = LOGGABLE_PARAMS.include?(key.to_s) ? value : ('*' * value.length)
           else # ex. ActionDispatch::Http::UploadedFile
             hash[key] = "[Instance of #{value.class}]"
           end

--- a/lib/carto/common/rack_logger_middleware.rb
+++ b/lib/carto/common/rack_logger_middleware.rb
@@ -8,12 +8,12 @@ module Carto
 
       # Complete with parameters that can be safely logged, as it is
       # safer to don't log anything by default.
-      LOGGABLE_PARAMS = %w(
+      LOGGABLE_PARAMS = %w[
         id
         username
         created_at
         updated_at
-      )
+      ].freeze
 
       private
 


### PR DESCRIPTION
**What does this PR do?**

- Changes the log level from `infor` to `error` for requests that have a `5xx` status but don't have an exception in the context of the request (for example, those handled from a Rails `rescue_from` statement).
- Fixes bug where string parameters where serialized as `Instance of <String>`
- Obfuscates all string parameters by default, instead of logging them by default.
- Replaces Hound by a GitHub actions (same as we do in Central)

Related tickets:

- https://app.clubhouse.io/cartoteam/story/95488/exception-trace-lost-and-logged-as-info
- https://app.clubhouse.io/cartoteam/story/95491/fix-bug-serializing-request-parameters

Related PRs:

- **Central**: https://github.com/CartoDB/cartodb-central/pull/2896/files
- **CartoDB**: *PENDING*