### PR TITLE
Logger: safe transformation into UTF-8 string

### DIFF
--- a/lib/carto/common/logger_formatter.rb
+++ b/lib/carto/common/logger_formatter.rb
@@ -15,13 +15,7 @@ module Carto
         replace_key(message_hash, :current_user, :'cdb-user')
         replace_key(message_hash, :message, :event_message)
 
-        message_hash.transform_values! do |value|
-          if value.is_a?(String)
-            value.encode('UTF-8', 'UTF-8', :invalid => :replace)
-          else
-            value
-          end
-        end
+        deep_safe_utf8_encode!(message_hash)
         development_environment? ? "#{JSON.pretty_generate(message_hash)}\n" : "#{message_hash.to_json}\n"
       end
 
@@ -41,6 +35,18 @@ module Carto
       def replace_key(message_hash, old_key, new_key)
         value = message_hash.delete(old_key)
         message_hash[new_key] = value if message_hash[new_key].nil?
+      end
+
+      def deep_safe_utf8_encode!(hash)
+        hash.transform_values! do |value|
+          if value.is_a?(String)
+            value.encode('UTF-8', 'UTF-8', :invalid => :replace)
+          elsif value.is_a?(Hash)
+            deep_safe_utf8_encode!(value)
+          else
+            value
+          end
+        end
       end
 
     end

--- a/lib/carto/common/logger_formatter.rb
+++ b/lib/carto/common/logger_formatter.rb
@@ -5,13 +5,15 @@ require 'json'
 module Carto
   module Common
     class LoggerFormatter < ::ActiveSupport::Logger::Formatter
-
       def call(severity, time, _progname, message)
         original_message = message.is_a?(Hash) ? message : { event_message: message }
 
         message_hash = deep_safe_utf8_encode(
           ActiveSupport::HashWithIndifferentAccess.new(
-            original_message.merge(timestamp: time, levelname: levelname(severity))
+            original_message.merge(
+              timestamp: time,
+              levelname: levelname(severity)
+            )
           )
         )
         replace_key(message_hash, :current_user, :'cdb-user')
@@ -41,7 +43,7 @@ module Carto
       def deep_safe_utf8_encode(hash)
         hash.transform_values do |value|
           if value.is_a?(String)
-            value.encode('UTF-8', 'UTF-8', :invalid => :replace)
+            value.encode('UTF-8', 'UTF-8', invalid: :replace)
           elsif value.is_a?(Hash)
             deep_safe_utf8_encode(value)
           else
@@ -49,7 +51,6 @@ module Carto
           end
         end
       end
-
     end
   end
 end

--- a/lib/carto/common/logger_formatter.rb
+++ b/lib/carto/common/logger_formatter.rb
@@ -15,6 +15,13 @@ module Carto
         replace_key(message_hash, :current_user, :'cdb-user')
         replace_key(message_hash, :message, :event_message)
 
+        message_hash.transform_values! do |value|
+          if value.is_a?(String)
+            value.encode('UTF-8', 'UTF-8', :invalid => :replace)
+          else
+            value
+          end
+        end
         development_environment? ? "#{JSON.pretty_generate(message_hash)}\n" : "#{message_hash.to_json}\n"
       end
 

--- a/spec/carto/common/logger_formatter_spec.rb
+++ b/spec/carto/common/logger_formatter_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe Carto::Common::LoggerFormatter do
       expect(parsed_output['message']).to be_nil
       expect(parsed_output['event_message']).to eq('Something!')
     end
+
+    it 'can deal with non-utf8 strings' do
+      payload = {
+        message: 'Something',
+        body: "some non-utf8 \xe2 char",
+        some_other_value: 42
+      }
+      output = subject.call(severity, time, progname, payload)
+      parsed_output = JSON.parse(output)
+
+      expect(parsed_output['event_message']).to eq('Something')
+      expect(parsed_output['body']).to eq('some non-utf8 � char')
+      expect(parsed_output['some_other_value']).to eq(42)
+    end
   end
 
   context 'severity format' do

--- a/spec/carto/common/logger_formatter_spec.rb
+++ b/spec/carto/common/logger_formatter_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe Carto::Common::LoggerFormatter do
       payload = {
         message: 'Something',
         body: "some non-utf8 \xe2 char",
+        some_nested_field: {
+          another_non_utf8: "another non-utf8 \xe2 char"
+        },
         some_other_value: 42
       }
       output = subject.call(severity, time, progname, payload)
@@ -49,6 +52,7 @@ RSpec.describe Carto::Common::LoggerFormatter do
 
       expect(parsed_output['event_message']).to eq('Something')
       expect(parsed_output['body']).to eq('some non-utf8 � char')
+      expect(parsed_output['some_nested_field']['another_non_utf8']).to eq('another non-utf8 � char')
       expect(parsed_output['some_other_value']).to eq(42)
     end
   end

--- a/spec/carto/common/logger_formatter_spec.rb
+++ b/spec/carto/common/logger_formatter_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe Carto::Common::LoggerFormatter do
 
       expect(parsed_output['event_message']).to eq('Something')
       expect(parsed_output['body']).to eq('some non-utf8 � char')
-      expect(parsed_output['some_nested_field']['another_non_utf8']).to eq('another non-utf8 � char')
+      expect(parsed_output['some_nested_field']['another_non_utf8'])
+        .to eq('another non-utf8 � char')
       expect(parsed_output['some_other_value']).to eq(42)
     end
   end


### PR DESCRIPTION
Indeed the errors we were seeing in rollbar come from these lines (rollbar show them, but it considers them to be part of the framework - "non-project frames"):

```
File /home/ubuntu/www/production.cartodb.com/shared/bundle/ruby/2.5.0/bundler/gems/cartodb-common-341004053e71/lib/carto/common/logger_formatter.rb line 18 in call
File /usr/lib/ruby/2.5.0/logger.rb line 584 in format_message
File /usr/lib/ruby/2.5.0/logger.rb line 472 in add
File /home/ubuntu/www/production.cartodb.com/shared/bundle/ruby/2.5.0/gems/activesupport-4.2.11.3/lib/active_support/logger.rb line 88 in add
File /usr/lib/ruby/2.5.0/logger.rb line 545 in error
```

This fixes it by recursively forcing the transformation into utf-8 strings and replacing unrecognized bytestring sequences by question mark characters.

Here's an interesting discussion about rails behavior with `to_json`: https://stackoverflow.com/questions/17936318/why-does-to-json-escape-unicode-automatically-in-rails-4