### PR TITLE
Rails 5 / Less strict dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.4
+          ruby-version: 2.5
 
       - name: Bundle install
         run: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     cartodb-common (0.3.6)
-      activesupport (~> 4.2.11.3)
-      argon2 (~> 2.0)
+      activesupport
+      argon2 (~> 2)
 
 GEM
   remote: https://rubygems.org/
@@ -124,12 +124,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionmailer (~> 4.2)
-  bundler (~> 2.0)
+  actionmailer
+  bundler (~> 2)
   byebug
   cartodb-common!
-  rake (~> 13.0)
-  rspec (~> 3.0)
+  rake (~> 13)
+  rspec (~> 3)
   rubocop
   rubocop-performance
   rubocop-rails

--- a/cartodb-utils.gemspec
+++ b/cartodb-utils.gemspec
@@ -1,17 +1,17 @@
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "carto/common/version"
+require 'carto/common/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "cartodb-common"
-  spec.version       = Carto::Common::VERSION
-  spec.authors       = ["CARTO"]
-  spec.summary       = "Gem with common tools for CartoDB, like encryption"
-  spec.homepage      = "https://github.com/CartoDB/cartodb-common"
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.require_paths = ["lib"]
-  spec.required_ruby_version = '~> 2.4'
+  spec.name = 'cartodb-common'
+  spec.version = Carto::Common::VERSION
+  spec.authors = ['CARTO']
+  spec.summary = 'Gem with common tools for CartoDB, like encryption'
+  spec.homepage = 'https://github.com/CartoDB/cartodb-common'
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '~> 2.5'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -19,14 +19,14 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   end
 
-  spec.add_dependency 'activesupport', '~> 4.2.11.3'
-  spec.add_dependency 'argon2', '~> 2.0'
+  spec.add_dependency 'activesupport'
+  spec.add_dependency 'argon2', '~> 2'
 
-  spec.add_development_dependency 'actionmailer', '~> 4.2'
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency 'actionmailer'
+  spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'byebug'
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'rake', '~> 13'
+  spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'rubocop-rails'


### PR DESCRIPTION
This PR relaxes the dependencies on `actionmailer` and `activesupport` so they are both compatible with Rails 4 & Rails 5

Related: https://app.clubhouse.io/cartoteam/story/115944/upgrade-central-to-rails-5