### PR TITLE
Add central_commands_subscription to broker config

### DIFF
--- a/lib/carto/common/message_broker.rb
+++ b/lib/carto/common/message_broker.rb
@@ -59,6 +59,10 @@ module Carto
           @config[setting_name.to_s]
         end
 
+        def respond_to_missing?
+          true
+        end
+
       end
 
       class Topic

--- a/lib/carto/common/message_broker.rb
+++ b/lib/carto/common/message_broker.rb
@@ -43,6 +43,9 @@ module Carto
 
         include Singleton
 
+        attr_reader :project_id,
+                    :central_commands_subscription
+
         def initialize
           if self.class.const_defined?(:Cartodb)
             config_module = Cartodb
@@ -52,15 +55,9 @@ module Carto
             raise "Couldn't find a suitable config module"
           end
 
-          @config = config_module.config[:message_broker]
-        end
-
-        def method_missing(setting_name)
-          @config[setting_name.to_s]
-        end
-
-        def respond_to_missing?
-          true
+          config = config_module.config[:message_broker]
+          @project_id = config['project_id']
+          @central_commands_subscription = config['central_commands_subscription']
         end
 
       end

--- a/lib/carto/common/message_broker.rb
+++ b/lib/carto/common/message_broker.rb
@@ -43,8 +43,6 @@ module Carto
 
         include Singleton
 
-        attr_reader :project_id
-
         def initialize
           if self.class.const_defined?(:Cartodb)
             config_module = Cartodb
@@ -54,8 +52,11 @@ module Carto
             raise "Couldn't find a suitable config module"
           end
 
-          config = config_module.config[:message_broker]
-          @project_id = config['project_id']
+          @config = config_module.config[:message_broker]
+        end
+
+        def method_missing(setting_name)
+          @config[setting_name.to_s]
         end
 
       end

--- a/spec/carto/common/message_broker_spec.rb
+++ b/spec/carto/common/message_broker_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Carto::Common::MessageBroker::Config do
     expect { Carto::Common::MessageBroker::Config.instance }.to raise_error "Couldn't find a suitable config module"
   end
 
-  it 'allows to read other config settings other than project_id' do
+  it 'allows to read other central_commands_subscription config setting' do
     config_module = Object.const_set(:Cartodb, Module.new)
     config_module.define_singleton_method(:config) do
       {

--- a/spec/carto/common/message_broker_spec.rb
+++ b/spec/carto/common/message_broker_spec.rb
@@ -119,6 +119,20 @@ RSpec.describe Carto::Common::MessageBroker::Config do
   it 'raises an error if neither is defined' do
     expect { Carto::Common::MessageBroker::Config.instance }.to raise_error "Couldn't find a suitable config module"
   end
+
+  it 'allows to read other config settings other than project_id' do
+    config_module = Object.const_set(:Cartodb, Module.new)
+    config_module.define_singleton_method(:config) do
+      {
+        message_broker: {
+          'project_id' => 'test-project-id',
+          'central_commands_subscription' => 'test-subscription-name'
+        }
+      }
+    end
+    expect(Carto::Common::MessageBroker::Config.instance.central_commands_subscription)
+      .to eql 'test-subscription-name'
+  end
 end
 
 RSpec.describe Carto::Common::MessageBroker::Topic do

--- a/spec/carto/common/message_broker_spec.rb
+++ b/spec/carto/common/message_broker_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Carto::Common::MessageBroker::Config do
         }
       }
     end
-    expect(Carto::Common::MessageBroker::Config.instance.central_commands_subscription)
+    expect(described_class.instance.central_commands_subscription)
       .to eql 'test-subscription-name'
   end
 end


### PR DESCRIPTION
Also mind that central and cloud/onprem configs are going to have
different fields.

~~Not a big fan of `method_missing` but I think it fits the bill in this particular case.~~. Edit: removed.