### PR TITLE
Add a new field `enabled` to the message broker config

### DIFF
--- a/lib/carto/common/message_broker.rb
+++ b/lib/carto/common/message_broker.rb
@@ -58,6 +58,11 @@ module Carto
           config = config_module.config[:message_broker]
           @project_id = config['project_id']
           @central_commands_subscription = config['central_commands_subscription']
+          @enabled = config['enabled']
+        end
+
+        def enabled?
+          @enabled || false
         end
 
       end

--- a/spec/carto/common/message_broker_spec.rb
+++ b/spec/carto/common/message_broker_spec.rb
@@ -134,28 +134,30 @@ RSpec.describe Carto::Common::MessageBroker::Config do
       .to eql 'test-subscription-name'
   end
 
-  it 'enabled? returns false if not defined' do
-    config_module = Object.const_set(:CartodbCentral, Module.new)
-    config_module.define_singleton_method(:config) do
-      { message_broker: {} }
+  describe '#enabled?' do
+    it 'returns false if not defined' do
+      config_module = Object.const_set(:CartodbCentral, Module.new)
+      config_module.define_singleton_method(:config) do
+        { message_broker: {} }
+      end
+      expect(described_class.instance.enabled?).to be false
     end
-    expect(described_class.instance.enabled?).to be false
-  end
 
-  it 'enabled? returns true when set to true' do
-    config_module = Object.const_set(:CartodbCentral, Module.new)
-    config_module.define_singleton_method(:config) do
-      { message_broker: { 'enabled' => true } }
+    it 'returns true when set to true' do
+      config_module = Object.const_set(:CartodbCentral, Module.new)
+      config_module.define_singleton_method(:config) do
+        { message_broker: { 'enabled' => true } }
+      end
+      expect(described_class.instance.enabled?).to be true
     end
-    expect(described_class.instance.enabled?).to be true
-  end
 
-  it 'enabled? returns false when set to false' do
-    config_module = Object.const_set(:CartodbCentral, Module.new)
-    config_module.define_singleton_method(:config) do
-      { message_broker: { 'enabled' => false } }
+    it 'returns false when set to false' do
+      config_module = Object.const_set(:CartodbCentral, Module.new)
+      config_module.define_singleton_method(:config) do
+        { message_broker: { 'enabled' => false } }
+      end
+      expect(described_class.instance.enabled?).to be false
     end
-    expect(described_class.instance.enabled?).to be false
   end
 end
 

--- a/spec/carto/common/message_broker_spec.rb
+++ b/spec/carto/common/message_broker_spec.rb
@@ -133,6 +133,30 @@ RSpec.describe Carto::Common::MessageBroker::Config do
     expect(described_class.instance.central_commands_subscription)
       .to eql 'test-subscription-name'
   end
+
+  it 'enabled? returns false if not defined' do
+    config_module = Object.const_set(:CartodbCentral, Module.new)
+    config_module.define_singleton_method(:config) do
+      { message_broker: {} }
+    end
+    expect(Carto::Common::MessageBroker::Config.instance.enabled?).to be false
+  end
+
+  it 'enabled? returns true when set to true' do
+    config_module = Object.const_set(:CartodbCentral, Module.new)
+    config_module.define_singleton_method(:config) do
+      { message_broker: { 'enabled' => true } }
+    end
+    expect(Carto::Common::MessageBroker::Config.instance.enabled?).to be true
+  end
+
+  it 'enabled? returns false when set to false' do
+    config_module = Object.const_set(:CartodbCentral, Module.new)
+    config_module.define_singleton_method(:config) do
+      { message_broker: { 'enabled' => false } }
+    end
+    expect(Carto::Common::MessageBroker::Config.instance.enabled?).to be false
+  end
 end
 
 RSpec.describe Carto::Common::MessageBroker::Topic do

--- a/spec/carto/common/message_broker_spec.rb
+++ b/spec/carto/common/message_broker_spec.rb
@@ -95,7 +95,7 @@ end
 
 RSpec.describe Carto::Common::MessageBroker::Config do
   before(:each) do
-    Carto::Common::MessageBroker::Config.instance_variable_set(:@singleton__instance__, nil)
+    described_class.instance_variable_set(:@singleton__instance__, nil)
     Object.send(:remove_const, :Cartodb) if Object.constants.include?(:Cartodb)
     Object.send(:remove_const, :CartodbCentral) if Object.constants.include?(:CartodbCentral)
   end
@@ -105,7 +105,7 @@ RSpec.describe Carto::Common::MessageBroker::Config do
     config_module.define_singleton_method(:config) do
       { message_broker: { 'project_id' => 'test-project-id' } }
     end
-    expect(Carto::Common::MessageBroker::Config.instance.project_id).to eql 'test-project-id'
+    expect(described_class.instance.project_id).to eql 'test-project-id'
   end
 
   it 'uses CartodbCentral config module if it exists' do
@@ -113,11 +113,11 @@ RSpec.describe Carto::Common::MessageBroker::Config do
     config_module.define_singleton_method(:config) do
       { message_broker: { 'project_id' => 'test-project-id' } }
     end
-    expect(Carto::Common::MessageBroker::Config.instance.project_id).to eql 'test-project-id'
+    expect(described_class.instance.project_id).to eql 'test-project-id'
   end
 
   it 'raises an error if neither is defined' do
-    expect { Carto::Common::MessageBroker::Config.instance }.to raise_error "Couldn't find a suitable config module"
+    expect { described_class.instance }.to raise_error "Couldn't find a suitable config module"
   end
 
   it 'allows to read other central_commands_subscription config setting' do
@@ -139,7 +139,7 @@ RSpec.describe Carto::Common::MessageBroker::Config do
     config_module.define_singleton_method(:config) do
       { message_broker: {} }
     end
-    expect(Carto::Common::MessageBroker::Config.instance.enabled?).to be false
+    expect(described_class.instance.enabled?).to be false
   end
 
   it 'enabled? returns true when set to true' do
@@ -147,7 +147,7 @@ RSpec.describe Carto::Common::MessageBroker::Config do
     config_module.define_singleton_method(:config) do
       { message_broker: { 'enabled' => true } }
     end
-    expect(Carto::Common::MessageBroker::Config.instance.enabled?).to be true
+    expect(described_class.instance.enabled?).to be true
   end
 
   it 'enabled? returns false when set to false' do
@@ -155,7 +155,7 @@ RSpec.describe Carto::Common::MessageBroker::Config do
     config_module.define_singleton_method(:config) do
       { message_broker: { 'enabled' => false } }
     end
-    expect(Carto::Common::MessageBroker::Config.instance.enabled?).to be false
+    expect(described_class.instance.enabled?).to be false
   end
 end
 


### PR DESCRIPTION
See https://app.clubhouse.io/cartoteam/story/121290/disable-central-publisher-s-code-through-configuration