### PR TITLE
Bug/ch122116/log traces from subscribers in json format

### DIFF
--- a/lib/carto/common/logger.rb
+++ b/lib/carto/common/logger.rb
@@ -7,7 +7,7 @@ module Carto
   module Common
     class Logger < ActiveSupport::Logger
 
-      def initialize(output_stream)
+      def initialize(output_stream = $stdout)
         super(output_stream)
         self.formatter = Carto::Common::LoggerFormatter.new
       end

--- a/lib/carto/common/logger_formatter.rb
+++ b/lib/carto/common/logger_formatter.rb
@@ -19,7 +19,7 @@ module Carto
 
         # Serialize Exception objects
         exception = message_hash[:exception]
-        if exception&.is_a?(Exception)
+        if exception.is_a?(Exception)
           message_hash[:exception] = {
             class: exception.class.name,
             message: exception.message,

--- a/lib/carto/common/logger_formatter.rb
+++ b/lib/carto/common/logger_formatter.rb
@@ -23,7 +23,7 @@ module Carto
           message_hash[:exception] = {
             class: exception.class.name,
             message: exception.message,
-            backtrace_hint: Rails.env.production? ? exception.backtrace&.take(10) : exception.backtrace
+            backtrace_hint: production_environment? ? exception.backtrace&.take(10) : exception.backtrace
           }
           message_hash[:message] = exception.message if message_hash[:message].blank?
         end
@@ -44,7 +44,11 @@ module Carto
       end
 
       def development_environment?
-        ENV['RAILS_ENV'].to_s.downcase == 'development'
+        ENV['RAILS_ENV'].to_s.casecmp('development').zero?
+      end
+
+      def production_environment?
+        ENV['RAILS_ENV'].to_s.casecmp('production').zero?
       end
 
       def replace_key(message_hash, old_key, new_key)

--- a/lib/carto/common/logger_formatter.rb
+++ b/lib/carto/common/logger_formatter.rb
@@ -16,6 +16,18 @@ module Carto
             )
           )
         )
+
+        # Serialize Exception objects
+        exception = message_hash[:exception]
+        if exception&.is_a?(Exception)
+          message_hash[:exception] = {
+            class: exception.class.name,
+            message: exception.message,
+            backtrace_hint: Rails.env.production? ? exception.backtrace&.take(10) : exception.backtrace
+          }
+          message_hash[:message] = exception.message if message_hash[:message].blank?
+        end
+
         replace_key(message_hash, :current_user, :'cdb-user')
         replace_key(message_hash, :message, :event_message)
 

--- a/lib/carto/common/message_broker.rb
+++ b/lib/carto/common/message_broker.rb
@@ -13,7 +13,7 @@ module Carto
         @pubsub = Google::Cloud::Pubsub.new(project: @project_id)
         @topics = {}
         @subscriptions = {}
-        @logger = logger || ::Logger.new
+        @logger = logger || ::Logger.new($stdout)
       end
 
       def get_topic(topic)
@@ -102,7 +102,7 @@ module Carto
           @subscription = @pubsub.get_subscription(subscription_name, project: project_id)
           @callbacks = {}
           @subscriber = nil
-          @logger = logger || ::Logger.new
+          @logger = logger || ::Logger.new($stdout)
         end
 
         def register_callback(message_type, &block)

--- a/lib/carto/common/message_broker.rb
+++ b/lib/carto/common/message_broker.rb
@@ -5,16 +5,15 @@ module Carto
   module Common
     class MessageBroker
 
-      include Singleton
+      attr_reader :logger, :project_id
 
-      attr_reader :project_id
-
-      def initialize
+      def initialize(logger:)
         @config = Config.instance
         @project_id = @config.project_id
         @pubsub = Google::Cloud::Pubsub.new(project: @project_id)
         @topics = {}
         @subscriptions = {}
+        @logger = logger || ::Logger.new
       end
 
       def get_topic(topic)
@@ -36,7 +35,8 @@ module Carto
         subscription_name = subscription.to_s
         @subscriptions[subscription] ||= Subscription.new(@pubsub,
                                                           project_id: @project_id,
-                                                          subscription_name: subscription_name)
+                                                          subscription_name: subscription_name,
+                                                          logger: logger)
       end
 
       class Config
@@ -102,7 +102,7 @@ module Carto
           @subscription = @pubsub.get_subscription(subscription_name, project: project_id)
           @callbacks = {}
           @subscriber = nil
-          @logger = logger || Rails.logger
+          @logger = logger || ::Logger.new
         end
 
         def register_callback(message_type, &block)

--- a/spec/carto/common/logger_formatter_spec.rb
+++ b/spec/carto/common/logger_formatter_spec.rb
@@ -82,6 +82,28 @@ RSpec.describe Carto::Common::LoggerFormatter do
     end
   end
 
+  context 'when serializing exceptions' do
+    let(:exception) { StandardError.new('Error body') }
+    let(:output) { subject.call(severity, time, progname, { exception: exception }) }
+    let(:parsed_output) { JSON.parse(output) }
+
+    it 'outputs the exception class' do
+      expect(parsed_output['exception']['class']).to eq('StandardError')
+    end
+
+    it 'outputs the exception message' do
+      expect(parsed_output['exception']['message']).to eq('Error body')
+    end
+
+    it 'outputs the exception backtrace' do
+      expect(parsed_output['exception']['backtrace']).to be_nil
+    end
+
+    it 'outputs the exception message as event_message if the latter is empty' do
+      expect(parsed_output['event_message']).to eq('Error body')
+    end
+  end
+
   it 'renames current_user to cdb-user' do
     output = subject.call(severity, time, progname, { message: 'Something!', current_user: 'peter' })
     parsed_output = JSON.parse(output)

--- a/spec/carto/common/message_broker/config_spec.rb
+++ b/spec/carto/common/message_broker/config_spec.rb
@@ -1,0 +1,69 @@
+require 'carto/common/message_broker'
+
+RSpec.describe Carto::Common::MessageBroker::Config do
+  before do
+    described_class.instance_variable_set(:@singleton__instance__, nil)
+    Object.send(:remove_const, :Cartodb) if Object.constants.include?(:Cartodb)
+    Object.send(:remove_const, :CartodbCentral) if Object.constants.include?(:CartodbCentral)
+  end
+
+  it 'uses Cartodb config module if it exists' do
+    config_module = Object.const_set(:Cartodb, Module.new)
+    config_module.define_singleton_method(:config) do
+      { message_broker: { 'project_id' => 'test-project-id' } }
+    end
+    expect(described_class.instance.project_id).to eql 'test-project-id'
+  end
+
+  it 'uses CartodbCentral config module if it exists' do
+    config_module = Object.const_set(:CartodbCentral, Module.new)
+    config_module.define_singleton_method(:config) do
+      { message_broker: { 'project_id' => 'test-project-id' } }
+    end
+    expect(described_class.instance.project_id).to eql 'test-project-id'
+  end
+
+  it 'raises an error if neither is defined' do
+    expect { described_class.instance }.to raise_error "Couldn't find a suitable config module"
+  end
+
+  it 'allows to read other central_commands_subscription config setting' do
+    config_module = Object.const_set(:Cartodb, Module.new)
+    config_module.define_singleton_method(:config) do
+      {
+        message_broker: {
+          'project_id' => 'test-project-id',
+          'central_commands_subscription' => 'test-subscription-name'
+        }
+      }
+    end
+    expect(described_class.instance.central_commands_subscription)
+      .to eql 'test-subscription-name'
+  end
+
+  describe '#enabled?' do
+    it 'returns false if not defined' do
+      config_module = Object.const_set(:CartodbCentral, Module.new)
+      config_module.define_singleton_method(:config) do
+        { message_broker: {} }
+      end
+      expect(described_class.instance.enabled?).to be false
+    end
+
+    it 'returns true when set to true' do
+      config_module = Object.const_set(:CartodbCentral, Module.new)
+      config_module.define_singleton_method(:config) do
+        { message_broker: { 'enabled' => true } }
+      end
+      expect(described_class.instance.enabled?).to be true
+    end
+
+    it 'returns false when set to false' do
+      config_module = Object.const_set(:CartodbCentral, Module.new)
+      config_module.define_singleton_method(:config) do
+        { message_broker: { 'enabled' => false } }
+      end
+      expect(described_class.instance.enabled?).to be false
+    end
+  end
+end

--- a/spec/carto/common/message_broker/subscription_spec.rb
+++ b/spec/carto/common/message_broker/subscription_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Carto::Common::MessageBroker::Subscription do
       expect(logger).to receive(:warn)
       expect(message).to receive(:attributes).and_return({ 'event' => 'dummy_command' })
       expect(message).to receive(:reject!)
-      expect(subscription.main_callback(message)).to eql nil
+      expect(subscription.main_callback(message)).to be_nil
     end
 
     it "logs an error if there's an unexpected exception within the callback, but acknowledges the message" do
@@ -76,7 +76,7 @@ RSpec.describe Carto::Common::MessageBroker::Subscription do
       expect(message).to receive(:attributes).and_return({ 'event' => 'dummy_command' })
       expect(logger).to receive(:error)
       expect(message).to receive(:ack!)
-      expect(subscription.main_callback(message)).to eql nil
+      expect(subscription.main_callback(message)).to be_nil
     end
   end
 end

--- a/spec/carto/common/message_broker/subscription_spec.rb
+++ b/spec/carto/common/message_broker/subscription_spec.rb
@@ -1,0 +1,82 @@
+require 'carto/common/message_broker'
+
+RSpec.describe Carto::Common::MessageBroker::Subscription do
+  let(:logger) { instance_double('Logger') }
+
+  describe '#initialize' do
+    it 'delegates on the pubsub object to get the subscription' do
+      pubsub = instance_double('PubsubDouble')
+      expect(pubsub).to receive(:get_subscription).with('test_subscription', project: 'test-project-id')
+
+      described_class.new(
+        pubsub,
+        project_id: 'test-project-id',
+        subscription_name: 'test_subscription',
+        logger: logger
+      )
+    end
+  end
+
+  describe '#main_callback' do
+    it 'dispatches messages to a registered callback' do
+      pubsub = instance_double('PubsubDouble')
+      expect(pubsub).to receive(:get_subscription).with('test_subscription', project: 'test-project-id')
+
+      subscription = described_class.new(
+        pubsub,
+        project_id: 'test-project-id',
+        subscription_name: 'test_subscription',
+        logger: logger
+      )
+      subscription.register_callback(:dummy_command) do |_payload|
+        'success!'
+      end
+
+      message = instance_double('PubsubMessageDouble')
+      expect(message).to receive(:data).and_return('{}')
+      expect(message).to receive(:attributes).and_return({ 'event' => 'dummy_command' })
+      expect(message).to receive(:ack!)
+      expect(subscription.main_callback(message)).to eql 'success!'
+    end
+
+    it "rejects a message if there's no callback registered for it" do
+      pubsub = instance_double('PubsubDouble')
+      expect(pubsub).to receive(:get_subscription).with('test_subscription', project: 'test-project-id')
+
+      subscription = described_class.new(
+        pubsub,
+        project_id: 'test-project-id',
+        subscription_name: 'test_subscription',
+        logger: logger
+      )
+
+      message = instance_double('PubsubMessageDouble')
+      expect(logger).to receive(:warn)
+      expect(message).to receive(:attributes).and_return({ 'event' => 'dummy_command' })
+      expect(message).to receive(:reject!)
+      expect(subscription.main_callback(message)).to eql nil
+    end
+
+    it "logs an error if there's an unexpected exception within the callback, but acknowledges the message" do
+      pubsub = instance_double('PubsubDouble')
+      expect(pubsub).to receive(:get_subscription).with('test_subscription', project: 'test-project-id')
+
+      subscription = described_class.new(
+        pubsub,
+        project_id: 'test-project-id',
+        subscription_name: 'test_subscription',
+        logger: logger
+      )
+      subscription.register_callback(:dummy_command) do
+        raise 'unexpected exception'
+      end
+
+      message = instance_double('PubsubMessageDouble')
+      expect(message).to receive(:data).and_return('{}')
+      expect(message).to receive(:attributes).and_return({ 'event' => 'dummy_command' })
+      expect(logger).to receive(:error)
+      expect(message).to receive(:ack!)
+      expect(subscription.main_callback(message)).to eql nil
+    end
+  end
+end

--- a/spec/carto/common/message_broker/topic_spec.rb
+++ b/spec/carto/common/message_broker/topic_spec.rb
@@ -1,0 +1,38 @@
+require 'carto/common/message_broker'
+
+RSpec.describe Carto::Common::MessageBroker::Topic do
+  describe '#initialize' do
+    it 'delegates on the pubsub instance to get the topic to be used' do
+      pubsub = instance_double('PubsubDouble')
+      expect(pubsub).to receive(:get_topic).with('projects/test-project-id/topics/my_topic')
+
+      my_topic = described_class.new(pubsub, project_id: 'test-project-id', topic: :my_topic)
+      expect(my_topic.project_id).to eql 'test-project-id'
+      expect(my_topic.topic_name).to eql 'my_topic'
+    end
+  end
+
+  describe '#publish' do
+    it 'delegates on the pubsub topic instance to publish events' do
+      pubsub = instance_double('PubsubDouble')
+      pubsub_topic = instance_double('Google::Cloud::Pubsub::Topic')
+      allow(pubsub).to receive(:get_topic).with('projects/test-project-id/topics/my_topic').and_return(pubsub_topic)
+      my_topic = described_class.new(pubsub, project_id: 'test-project-id', topic: :my_topic)
+
+      expect(pubsub_topic).to receive(:publish).with('{}', { event: 'test_event' })
+      my_topic.publish(:test_event, {})
+    end
+  end
+
+  describe '#create_subscription' do
+    it 'delegates on the pubsub topic instance to create subscriptions' do
+      pubsub = instance_double('PubsubDouble')
+      pubsub_topic = instance_double('Google::Cloud::Pubsub::Topic')
+      allow(pubsub).to receive(:get_topic).with('projects/test-project-id/topics/my_topic').and_return(pubsub_topic)
+      my_topic = described_class.new(pubsub, project_id: 'test-project-id', topic: :my_topic)
+
+      expect(pubsub_topic).to receive(:create_subscription).with('my_subscription', {})
+      my_topic.create_subscription('my_subscription')
+    end
+  end
+end

--- a/spec/carto/common/message_broker_spec.rb
+++ b/spec/carto/common/message_broker_spec.rb
@@ -3,6 +3,10 @@ require 'carto/common/message_broker'
 require 'logger'
 
 RSpec.describe Carto::Common::MessageBroker do
+  subject(:message_broker) { described_class.new(logger: logger) }
+
+  let(:logger) { ::Logger.new($stdout) }
+
   before do
     described_class.instance_variable_set(:@singleton__instance__, nil)
   end
@@ -13,7 +17,7 @@ RSpec.describe Carto::Common::MessageBroker do
       expect(Carto::Common::MessageBroker::Config).to receive(:instance).and_return(config)
       expect(Google::Cloud::Pubsub).to receive(:new).with(project: 'test-project-id')
 
-      expect(described_class.instance.project_id).to eql 'test-project-id'
+      expect(message_broker.project_id).to eql 'test-project-id'
     end
   end
 
@@ -26,7 +30,7 @@ RSpec.describe Carto::Common::MessageBroker do
       expect(Carto::Common::MessageBroker::Topic).to receive(:new).with(pubsub,
                                                                         project_id: 'test-project-id',
                                                                         topic: 'dummy_topic')
-      described_class.instance.get_topic(:dummy_topic)
+      message_broker.get_topic(:dummy_topic)
     end
   end
 
@@ -40,7 +44,7 @@ RSpec.describe Carto::Common::MessageBroker do
       allow(Google::Cloud::Pubsub).to receive(:new).with(project: 'test-project-id').and_return(pubsub)
       expect(pubsub).to receive(:create_topic).with('dummy_topic')
       expect(Carto::Common::MessageBroker::Topic).to receive(:new).and_return(topic)
-      expect(described_class.instance.create_topic(:dummy_topic)).to eql topic
+      expect(message_broker.create_topic(:dummy_topic)).to eql topic
     end
   end
 
@@ -51,11 +55,14 @@ RSpec.describe Carto::Common::MessageBroker do
       config = instance_double('Config', project_id: 'test-project-id')
       allow(Carto::Common::MessageBroker::Config).to receive(:instance).and_return(config)
       allow(Google::Cloud::Pubsub).to receive(:new).with(project: 'test-project-id').and_return(pubsub)
-      allow(Carto::Common::MessageBroker::Subscription).to receive(:new).with(pubsub,
-                                                                              project_id: 'test-project-id',
-                                                                              subscription_name: 'dummy_subscription')
+      allow(Carto::Common::MessageBroker::Subscription).to(
+        receive(:new).with(
+          pubsub,
+          hash_including(project_id: 'test-project-id', subscription_name: 'dummy_subscription')
+        )
+      )
 
-      described_class.instance.get_subscription(:dummy_subscription)
+      message_broker.get_subscription(:dummy_subscription)
     end
   end
 end

--- a/spec/carto/common/message_broker_spec.rb
+++ b/spec/carto/common/message_broker_spec.rb
@@ -2,42 +2,9 @@ require 'spec_helper'
 require 'carto/common/message_broker'
 require 'logger'
 
-# See https://relishapp.com/rspec/rspec-mocks/v/3-0/docs/verifying-doubles/dynamic-classes
-# rubocop:disable Lint/UselessMethodDefinition
-class PubsubDouble
-
-  include Google::Cloud::Pubsub
-
-  def create_topic(*)
-    super
-  end
-
-  def get_topic(*)
-    super
-  end
-
-  def get_subscription(*)
-    super
-  end
-
-end
-
-class PubsubMessageDouble < Google::Cloud::Pubsub::Message
-
-  def ack!(*)
-    super
-  end
-
-  def reject!(*)
-    super
-  end
-
-end
-# rubocop:enable Lint/UselessMethodDefinition
-
 RSpec.describe Carto::Common::MessageBroker do
-  before(:each) do
-    Carto::Common::MessageBroker.instance_variable_set(:@singleton__instance__, nil)
+  before do
+    described_class.instance_variable_set(:@singleton__instance__, nil)
   end
 
   describe '#initialize' do
@@ -46,7 +13,7 @@ RSpec.describe Carto::Common::MessageBroker do
       expect(Carto::Common::MessageBroker::Config).to receive(:instance).and_return(config)
       expect(Google::Cloud::Pubsub).to receive(:new).with(project: 'test-project-id')
 
-      expect(Carto::Common::MessageBroker.instance.project_id).to eql 'test-project-id'
+      expect(described_class.instance.project_id).to eql 'test-project-id'
     end
   end
 
@@ -59,7 +26,7 @@ RSpec.describe Carto::Common::MessageBroker do
       expect(Carto::Common::MessageBroker::Topic).to receive(:new).with(pubsub,
                                                                         project_id: 'test-project-id',
                                                                         topic: 'dummy_topic')
-      Carto::Common::MessageBroker.instance.get_topic(:dummy_topic)
+      described_class.instance.get_topic(:dummy_topic)
     end
   end
 
@@ -73,7 +40,7 @@ RSpec.describe Carto::Common::MessageBroker do
       allow(Google::Cloud::Pubsub).to receive(:new).with(project: 'test-project-id').and_return(pubsub)
       expect(pubsub).to receive(:create_topic).with('dummy_topic')
       expect(Carto::Common::MessageBroker::Topic).to receive(:new).and_return(topic)
-      expect(Carto::Common::MessageBroker.instance.create_topic(:dummy_topic)).to eql topic
+      expect(described_class.instance.create_topic(:dummy_topic)).to eql topic
     end
   end
 
@@ -88,185 +55,7 @@ RSpec.describe Carto::Common::MessageBroker do
                                                                               project_id: 'test-project-id',
                                                                               subscription_name: 'dummy_subscription')
 
-      Carto::Common::MessageBroker.instance.get_subscription(:dummy_subscription)
-    end
-  end
-end
-
-RSpec.describe Carto::Common::MessageBroker::Config do
-  before(:each) do
-    described_class.instance_variable_set(:@singleton__instance__, nil)
-    Object.send(:remove_const, :Cartodb) if Object.constants.include?(:Cartodb)
-    Object.send(:remove_const, :CartodbCentral) if Object.constants.include?(:CartodbCentral)
-  end
-
-  it 'uses Cartodb config module if it exists' do
-    config_module = Object.const_set(:Cartodb, Module.new)
-    config_module.define_singleton_method(:config) do
-      { message_broker: { 'project_id' => 'test-project-id' } }
-    end
-    expect(described_class.instance.project_id).to eql 'test-project-id'
-  end
-
-  it 'uses CartodbCentral config module if it exists' do
-    config_module = Object.const_set(:CartodbCentral, Module.new)
-    config_module.define_singleton_method(:config) do
-      { message_broker: { 'project_id' => 'test-project-id' } }
-    end
-    expect(described_class.instance.project_id).to eql 'test-project-id'
-  end
-
-  it 'raises an error if neither is defined' do
-    expect { described_class.instance }.to raise_error "Couldn't find a suitable config module"
-  end
-
-  it 'allows to read other central_commands_subscription config setting' do
-    config_module = Object.const_set(:Cartodb, Module.new)
-    config_module.define_singleton_method(:config) do
-      {
-        message_broker: {
-          'project_id' => 'test-project-id',
-          'central_commands_subscription' => 'test-subscription-name'
-        }
-      }
-    end
-    expect(described_class.instance.central_commands_subscription)
-      .to eql 'test-subscription-name'
-  end
-
-  describe '#enabled?' do
-    it 'returns false if not defined' do
-      config_module = Object.const_set(:CartodbCentral, Module.new)
-      config_module.define_singleton_method(:config) do
-        { message_broker: {} }
-      end
-      expect(described_class.instance.enabled?).to be false
-    end
-
-    it 'returns true when set to true' do
-      config_module = Object.const_set(:CartodbCentral, Module.new)
-      config_module.define_singleton_method(:config) do
-        { message_broker: { 'enabled' => true } }
-      end
-      expect(described_class.instance.enabled?).to be true
-    end
-
-    it 'returns false when set to false' do
-      config_module = Object.const_set(:CartodbCentral, Module.new)
-      config_module.define_singleton_method(:config) do
-        { message_broker: { 'enabled' => false } }
-      end
-      expect(described_class.instance.enabled?).to be false
-    end
-  end
-end
-
-RSpec.describe Carto::Common::MessageBroker::Topic do
-  describe '#initialize' do
-    it 'delegates on the pubsub instance to get the topic to be used' do
-      pubsub = instance_double('PubsubDouble')
-      expect(pubsub).to receive(:get_topic).with('projects/test-project-id/topics/my_topic')
-
-      my_topic = Carto::Common::MessageBroker::Topic.new(pubsub, project_id: 'test-project-id', topic: :my_topic)
-      expect(my_topic.project_id).to eql 'test-project-id'
-      expect(my_topic.topic_name).to eql 'my_topic'
-    end
-  end
-
-  describe '#publish' do
-    it 'delegates on the pubsub topic instance to publish events' do
-      pubsub = instance_double('PubsubDouble')
-      pubsub_topic = instance_double('Google::Cloud::Pubsub::Topic')
-      allow(pubsub).to receive(:get_topic).with('projects/test-project-id/topics/my_topic').and_return(pubsub_topic)
-      my_topic = Carto::Common::MessageBroker::Topic.new(pubsub, project_id: 'test-project-id', topic: :my_topic)
-
-      expect(pubsub_topic).to receive(:publish).with('{}', { event: 'test_event' })
-      my_topic.publish(:test_event, {})
-    end
-  end
-
-  describe '#create_subscription' do
-    it 'delegates on the pubsub topic instance to create subscriptions' do
-      pubsub = instance_double('PubsubDouble')
-      pubsub_topic = instance_double('Google::Cloud::Pubsub::Topic')
-      allow(pubsub).to receive(:get_topic).with('projects/test-project-id/topics/my_topic').and_return(pubsub_topic)
-      my_topic = Carto::Common::MessageBroker::Topic.new(pubsub, project_id: 'test-project-id', topic: :my_topic)
-
-      expect(pubsub_topic).to receive(:create_subscription).with('my_subscription', {})
-      my_topic.create_subscription('my_subscription')
-    end
-  end
-end
-
-RSpec.describe Carto::Common::MessageBroker::Subscription do
-  let(:logger) { instance_double('Logger') }
-
-  describe '#initialize' do
-    it 'delegates on the pubsub object to get the subscription' do
-      pubsub = instance_double('PubsubDouble')
-      expect(pubsub).to receive(:get_subscription).with('test_subscription', project: 'test-project-id')
-
-      Carto::Common::MessageBroker::Subscription.new(pubsub,
-                                                     project_id: 'test-project-id',
-                                                     subscription_name: 'test_subscription',
-                                                     logger: logger)
-    end
-  end
-
-  describe '#main_callback' do
-    it 'dispatches messages to a registered callback' do
-      pubsub = instance_double('PubsubDouble')
-      expect(pubsub).to receive(:get_subscription).with('test_subscription', project: 'test-project-id')
-
-      subscription = Carto::Common::MessageBroker::Subscription.new(pubsub,
-                                                                    project_id: 'test-project-id',
-                                                                    subscription_name: 'test_subscription',
-                                                                    logger: logger)
-      subscription.register_callback(:dummy_command) do |_payload|
-        'success!'
-      end
-
-      message = instance_double('PubsubMessageDouble')
-      expect(message).to receive(:data).and_return('{}')
-      expect(message).to receive(:attributes).and_return({ 'event' => 'dummy_command' })
-      expect(message).to receive(:ack!)
-      expect(subscription.main_callback(message)).to eql 'success!'
-    end
-
-    it "rejects a message if there's no callback registered for it" do
-      pubsub = instance_double('PubsubDouble')
-      expect(pubsub).to receive(:get_subscription).with('test_subscription', project: 'test-project-id')
-
-      subscription = Carto::Common::MessageBroker::Subscription.new(pubsub,
-                                                                    project_id: 'test-project-id',
-                                                                    subscription_name: 'test_subscription',
-                                                                    logger: logger)
-
-      message = instance_double('PubsubMessageDouble')
-      expect(logger).to receive(:warn)
-      expect(message).to receive(:attributes).and_return({ 'event' => 'dummy_command' })
-      expect(message).to receive(:reject!)
-      expect(subscription.main_callback(message)).to eql nil
-    end
-
-    it "logs an error if there's an unexpected exception within the callback, but acknowledges the message" do
-      pubsub = instance_double('PubsubDouble')
-      expect(pubsub).to receive(:get_subscription).with('test_subscription', project: 'test-project-id')
-
-      subscription = Carto::Common::MessageBroker::Subscription.new(pubsub,
-                                                                    project_id: 'test-project-id',
-                                                                    subscription_name: 'test_subscription',
-                                                                    logger: logger)
-      subscription.register_callback(:dummy_command) do
-        raise 'unexpected exception'
-      end
-
-      message = instance_double('PubsubMessageDouble')
-      expect(message).to receive(:data).and_return('{}')
-      expect(message).to receive(:attributes).and_return({ 'event' => 'dummy_command' })
-      expect(logger).to receive(:error)
-      expect(message).to receive(:ack!)
-      expect(subscription.main_callback(message)).to eql nil
+      described_class.instance.get_subscription(:dummy_subscription)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "carto/common/encryption_service"
 require "carto/common/logger_formatter"
+require 'google/cloud/pubsub'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -13,3 +14,36 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+# See https://relishapp.com/rspec/rspec-mocks/v/3-0/docs/verifying-doubles/dynamic-classes
+# rubocop:disable Lint/UselessMethodDefinition
+class PubsubDouble
+
+  include Google::Cloud::Pubsub
+
+  def create_topic(*)
+    super
+  end
+
+  def get_topic(*)
+    super
+  end
+
+  def get_subscription(*)
+    super
+  end
+
+end
+
+class PubsubMessageDouble < Google::Cloud::Pubsub::Message
+
+  def ack!(*)
+    super
+  end
+
+  def reject!(*)
+    super
+  end
+
+end
+# rubocop:enable Lint/UselessMethodDefinition


### PR DESCRIPTION
Related to: https://app.clubhouse.io/cartoteam/story/122116/log-traces-from-subscribers-in-json-format

**What does this PR do?**

- Allows providing a logger to `MessageBroker`, so each application using it can decide if log to stdout or a file.
- Splits the specs in `message_broker_spec.rb` so each class is tested in its own file.
- Adds Exception serialization logic to `Carto::Common::Logger`, so we can remove that from the `LoggerHelper` and drop the dependency on the `LoggerHelper` from the subscribers.

**Acceptance**

I've tested this in Central staging by deploying https://github.com/CartoDB/cartodb-central/pull/2987/files and it looked ok:

```json
/* central-que-01.stag.cartodb.net */
/* /home/ubuntu/www/production.cartodb.com/shared/log/message_broker-central_subscribers.log */
{"subscription_name":"cartodb_central","timestamp":"2020-11-26T12:08:50.167+00:00","levelname":"info","cdb-user":null,"event_message":"Starting message processing in subscriber"}
{"timestamp":"2020-11-26T12:08:50.179+00:00","levelname":"info","cdb-user":null,"event_message":"Consuming messages from subscription :cartodb_central"}
{"subscription_name":"cartodb_central","message_type":"amiedes_test","timestamp":"2020-11-26T12:08:51.061+00:00","levelname":"warning","cdb-user":null,"event_message":"No callback registered for message"}
{"subscription_name":"cartodb_central","message_type":"amiedes_test","timestamp":"2020-11-26T12:08:51.062+00:00","levelname":"warning","cdb-user":null,"event_message":"No callback registered for message"}
```