### PR TITLE
Fix rollbar reporting

### DIFF
--- a/lib/carto/common/action_controller_log_subscriber.rb
+++ b/lib/carto/common/action_controller_log_subscriber.rb
@@ -41,7 +41,11 @@ module Carto
         end
         log_entry.merge!(status: status, status_text: Rack::Utils::HTTP_STATUS_CODES[status])
 
-        exception.present? || status.to_s.match?(/5\d\d/) ? error(log_entry) : info(log_entry)
+        if exception.present? || status.to_s.match?(/5\d\d/)
+          error(log_entry.merge(rollbar: false))
+        else
+          info(log_entry)
+        end
       end
 
       def halted_callback(event)

--- a/lib/carto/common/logger.rb
+++ b/lib/carto/common/logger.rb
@@ -63,13 +63,25 @@ module Carto
       end
 
       def error(params = {})
+        rollbar = if params.is_a?(Hash)
+                    params.delete(:rollbar) != false
+                  else
+                    true
+                  end
+
         super(params)
-        send_exception_to_rollbar(params)
+        send_exception_to_rollbar(params) if rollbar
       end
 
       def fatal(params = {})
+        rollbar = if params.is_a?(Hash)
+                    params.delete(:rollbar) != false
+                  else
+                    true
+                  end
+
         super(params)
-        send_exception_to_rollbar(params)
+        send_exception_to_rollbar(params) if rollbar
       end
 
       private

--- a/spec/carto/common/action_controller_log_subscriber_spec.rb
+++ b/spec/carto/common/action_controller_log_subscriber_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+require './lib/carto/common/action_controller_log_subscriber'
+
+RSpec.describe Carto::Common::ActionControllerLogSubscriber do
+  subject(:log_subscriber) { described_class.new }
+
+  let(:event_name) {}
+  let(:event_payload) { {} }
+  let(:event) do
+    ActiveSupport::Notifications::Event.new(
+      event_name,
+      Time.current,
+      Time.current + 1.second, 1,
+      event_payload
+    )
+  end
+
+  describe '#process_action' do
+    let(:event_name) { 'start_processing.action_controller' }
+    let(:base_payload) do
+      {
+        controller: 'UsersController',
+        action: 'index',
+        params: { 'action' => 'index', 'controller' => 'users' },
+        headers: ActionDispatch::Http::Headers.new({}),
+        format: :html,
+        method: 'GET',
+        path: '/users'
+      }
+    end
+
+    context 'when exception is present' do
+      let(:event_payload) { base_payload.merge(status: 500, exception: [StandardError.new('Exception message')]) }
+
+      it 'logs request completion' do
+        expect(log_subscriber).to receive(:error).with(
+          message: 'Request completed',
+          request_id: nil,
+          current_user: nil,
+          duration_ms: 1000,
+          view_duration_ms: nil,
+          db_duration_ms: nil,
+          status: 500,
+          status_text: 'Internal Server Error',
+          rollbar: false,
+          exception: { message: 'Exception message' }
+        )
+
+        log_subscriber.process_action(event)
+      end
+    end
+
+    context 'when returning an error code without exception' do
+      let(:event_payload) { base_payload.merge(status: 500) }
+
+      it 'logs request completion' do
+        expect(log_subscriber).to receive(:error).with(
+          message: 'Request completed',
+          request_id: nil,
+          current_user: nil,
+          duration_ms: 1000,
+          view_duration_ms: nil,
+          db_duration_ms: nil,
+          status: 500,
+          status_text: 'Internal Server Error',
+          rollbar: false
+        )
+
+        log_subscriber.process_action(event)
+      end
+    end
+
+    context 'when everything is ok' do
+      let(:event_payload) { base_payload.merge(status: 200) }
+
+      it 'logs request completion' do
+        expect(log_subscriber).to receive(:info).with(
+          message: 'Request completed',
+          request_id: nil,
+          current_user: nil,
+          duration_ms: 1000,
+          view_duration_ms: nil,
+          db_duration_ms: nil,
+          status: 200,
+          status_text: 'OK'
+        )
+
+        log_subscriber.process_action(event)
+      end
+    end
+  end
+end

--- a/spec/carto/common/logger_spec.rb
+++ b/spec/carto/common/logger_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Carto::Common::Logger do
 
       logger.error(message)
     end
+
+    it 'allows skipping logging to Rollbar' do
+      expect(Rollbar).not_to receive(:error)
+
+      logger.error(message: message, rollbar: false)
+    end
   end
 
   describe '#fatal' do
@@ -30,7 +36,13 @@ RSpec.describe Carto::Common::Logger do
     it 'logs simple messages to Rollbar' do
       expect(Rollbar).to receive(:error).with(message)
 
-      logger.error(message)
+      logger.fatal(message)
+    end
+
+    it 'allows skipping logging to Rollbar' do
+      expect(Rollbar).not_to receive(:error)
+
+      logger.fatal(message: message, rollbar: false)
     end
   end
 end


### PR DESCRIPTION
Prevents misleading log messages in Rollbar when outputting the default "Request completed" message when Rails is returning a 500 error but there isn't an underlying exception object.