### PR TITLE
Propagate request_id in all logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .idea
 pkg/
 .byebug_history
+tmp/*
+!tmp/.keep

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,10 @@
 inherit_from:
   - https://raw.githubusercontent.com/CartoDB/cartodb/master/.rubocop.yml
+
+####################
+#  Naming
+####################
+
+Naming/FileName:
+  Exclude:
+    - lib/cartodb-common.rb

--- a/lib/carto/common/controller_helper.rb
+++ b/lib/carto/common/controller_helper.rb
@@ -1,0 +1,18 @@
+require 'carto/common/current_request'
+
+module Carto
+  module Common
+    module ControllerHelper
+
+      def set_request_id
+        Carto::Common::CurrentRequest.request_id = request.uuid
+        begin
+          yield
+        ensure
+          Carto::Common::CurrentRequest.request_id = nil
+        end
+      end
+
+    end
+  end
+end

--- a/lib/carto/common/current_request.rb
+++ b/lib/carto/common/current_request.rb
@@ -1,0 +1,22 @@
+module Carto
+  module Common
+    module CurrentRequest
+
+      def self.request_id
+        Thread.current[:request_id]
+      end
+
+      def self.request_id=(request_id)
+        Thread.current[:request_id] = request_id
+      end
+
+      def self.with_request_id(request_id)
+        self.request_id = request_id if request_id
+        yield
+      ensure
+        self.request_id = nil
+      end
+
+    end
+  end
+end

--- a/lib/carto/common/helpers/environment_helper.rb
+++ b/lib/carto/common/helpers/environment_helper.rb
@@ -1,0 +1,25 @@
+module EnvironmentHelper
+
+  def development_environment?
+    rails_env.casecmp('development').zero?
+  end
+
+  def test_environment?
+    rails_env.casecmp('test').zero?
+  end
+
+  def staging_environment?
+    rails_env.casecmp('staging').zero?
+  end
+
+  def production_environment?
+    rails_env.casecmp('production').zero?
+  end
+
+  private
+
+  def rails_env
+    ENV['RAILS_ENV'].to_s
+  end
+
+end

--- a/lib/carto/common/logger.rb
+++ b/lib/carto/common/logger.rb
@@ -62,6 +62,21 @@ module Carto
         self.formatter = Carto::Common::LoggerFormatter.new
       end
 
+      def debug(params = {})
+        merge_request_id!(params)
+        super(params)
+      end
+
+      def info(params = {})
+        merge_request_id!(params)
+        super(params)
+      end
+
+      def warn(params = {})
+        merge_request_id!(params)
+        super(params)
+      end
+
       def error(params = {})
         rollbar = if params.is_a?(Hash)
                     params.delete(:rollbar) != false
@@ -69,6 +84,7 @@ module Carto
                     true
                   end
 
+        merge_request_id!(params)
         super(params)
         send_exception_to_rollbar(params) if rollbar
       end
@@ -80,11 +96,20 @@ module Carto
                     true
                   end
 
+        merge_request_id!(params)
         super(params)
         send_exception_to_rollbar(params) if rollbar
       end
 
       private
+
+      def merge_request_id!(params)
+        return unless params.is_a?(Hash)
+
+        request_id = Carto::Common::CurrentRequest.request_id
+
+        params.merge!(request_id: request_id) if params[:request_id].blank? && request_id
+      end
 
       def send_exception_to_rollbar(params = {})
         if params.is_a?(Hash)

--- a/lib/carto/common/logger_formatter.rb
+++ b/lib/carto/common/logger_formatter.rb
@@ -1,10 +1,14 @@
 require 'active_support'
 require 'active_support/core_ext'
 require 'json'
+require_relative './helpers/environment_helper'
 
 module Carto
   module Common
     class LoggerFormatter < ::ActiveSupport::Logger::Formatter
+
+      include ::EnvironmentHelper
+
       def call(severity, time, _progname, message)
         original_message = message.is_a?(Hash) ? message : { event_message: message }
 
@@ -41,14 +45,6 @@ module Carto
 
         level = severity.to_s.downcase
         level == "warn" ? "warning" : level
-      end
-
-      def development_environment?
-        ENV['RAILS_ENV'].to_s.casecmp('development').zero?
-      end
-
-      def production_environment?
-        ENV['RAILS_ENV'].to_s.casecmp('production').zero?
       end
 
       def replace_key(message_hash, old_key, new_key)

--- a/lib/cartodb-common.rb
+++ b/lib/cartodb-common.rb
@@ -1,4 +1,6 @@
+require_relative 'carto/common/controller_helper'
 require_relative 'carto/common/countries_helper'
+require_relative 'carto/common/current_request'
 require_relative 'carto/common/encryption_service'
 require_relative 'carto/common/job_logger'
 require_relative 'carto/common/logger'

--- a/spec/carto/common/controller_helper_spec.rb
+++ b/spec/carto/common/controller_helper_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require './lib/carto/common/controller_helper'
+
+class ControllerMock
+
+  class Request
+
+    attr_accessor :uuid
+
+    def initialize
+      self.uuid = SecureRandom.hex
+    end
+
+  end
+
+  include Carto::Common::ControllerHelper
+
+  def index
+    set_request_id do
+      logger.info(request_id: Carto::Common::CurrentRequest.request_id)
+    end
+  end
+
+  def logger
+    @logger ||= Carto::Common::Logger.new
+  end
+
+  private
+
+  def request
+    @request ||= Request.new
+  end
+
+end
+
+RSpec.describe Carto::Common::ControllerHelper do
+  describe '#set_request_id' do
+    let(:controller) { ControllerMock.new }
+
+    it 'sets the request ID for each request' do
+      expect(controller.logger).to receive(:info).with(hash_including(request_id: kind_of(String)))
+
+      controller.index
+    end
+
+    it 'clears the thread-level variable after the request finishes' do
+      controller.index
+
+      expect(Carto::Common::CurrentRequest.request_id).to be_nil
+    end
+  end
+end

--- a/spec/carto/common/message_broker_spec.rb
+++ b/spec/carto/common/message_broker_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe Carto::Common::MessageBroker do
       pubsub = instance_double('Google::Cloud::Pubsub')
       allow(Carto::Common::MessageBroker::Config).to receive(:instance).and_return(config)
       allow(Google::Cloud::Pubsub).to receive(:new).with(project: 'test-project-id').and_return(pubsub)
-      expect(Carto::Common::MessageBroker::Topic).to receive(:new).with(pubsub,
-                                                                        project_id: 'test-project-id',
-                                                                        topic_name: 'broker_dummy_topic')
+      expect(Carto::Common::MessageBroker::Topic).to(
+        receive(:new).with(pubsub, hash_including(project_id: 'test-project-id', topic_name: 'broker_dummy_topic'))
+      )
       message_broker.get_topic(:dummy_topic)
     end
   end

--- a/spec/support/log_device_mock.rb
+++ b/spec/support/log_device_mock.rb
@@ -1,0 +1,20 @@
+class LogDeviceMock < Logger::LogDevice
+
+  attr_accessor :written_text
+
+  def write(text)
+    super(text)
+    self.written_text = '' unless written_text
+    self.written_text += text
+  end
+
+  def self.capture_output(logger)
+    original_log_device = logger.instance_variable_get(:@logdev)
+    mock_log_device = new('tmp/log_device_mock.log')
+    logger.instance_variable_set(:@logdev, mock_log_device)
+    yield
+    logger.instance_variable_set(:@logdev, original_log_device)
+    mock_log_device.written_text
+  end
+
+end


### PR DESCRIPTION
Related: https://app.clubhouse.io/cartoteam/story/122437/logs-should-propagate-the-request-id

## What does this PR do?

Provides the necessary utilities to propagate the request_id in the MessageBroker logs from CartoDB + Central

Related PR's:

- https://github.com/CartoDB/cartodb-central/pull/3001
- https://github.com/CartoDB/cartodb/pull/16006