### PR TITLE
Fix missing request_id

### DIFF
--- a/lib/carto/common/message_broker.rb
+++ b/lib/carto/common/message_broker.rb
@@ -208,7 +208,7 @@ module Carto
           if message_callback
             begin
               payload = JSON.parse(received_message.data)
-              request_id = payload.delete(:request_id)
+              request_id = payload.delete('request_id')
               message = Message.new(
                 payload: payload,
                 request_id: request_id,

--- a/spec/carto/common/message_broker/subscription_spec.rb
+++ b/spec/carto/common/message_broker/subscription_spec.rb
@@ -80,9 +80,7 @@ RSpec.describe Carto::Common::MessageBroker::Subscription do
         logger: logger
       )
       subscription.register_callback(:dummy_command) do |message|
-        if message.payload == {} && message.request_id == 'test-request-id'
-          'success!'
-        end
+        message.payload == {} && message.request_id == 'test-request-id' && 'success!'
       end
 
       message = instance_double('PubsubMessageDouble')
@@ -91,7 +89,6 @@ RSpec.describe Carto::Common::MessageBroker::Subscription do
       expect(message).to receive(:ack!)
       expect(subscription.main_callback(message)).to eql 'success!'
     end
-
 
     it "acknowledges a message and logs an error if there's no callback registered for it" do
       pubsub = instance_double('PubsubDouble')

--- a/spec/carto/common/message_broker/subscription_spec.rb
+++ b/spec/carto/common/message_broker/subscription_spec.rb
@@ -69,6 +69,30 @@ RSpec.describe Carto::Common::MessageBroker::Subscription do
       expect(subscription.main_callback(message)).to eql 'success!'
     end
 
+    it 'dispatches the request_id as an attribute of the message and removes it from the payload, when present' do
+      pubsub = instance_double('PubsubDouble')
+      expect(pubsub).to receive(:get_subscription).with('test_subscription', project: 'test-project-id')
+
+      subscription = described_class.new(
+        pubsub,
+        project_id: 'test-project-id',
+        subscription_name: 'test_subscription',
+        logger: logger
+      )
+      subscription.register_callback(:dummy_command) do |message|
+        if message.payload == {} && message.request_id == 'test-request-id'
+          'success!'
+        end
+      end
+
+      message = instance_double('PubsubMessageDouble')
+      expect(message).to receive(:data).and_return('{ "request_id": "test-request-id" }')
+      expect(message).to receive(:attributes).and_return({ 'event' => 'dummy_command' })
+      expect(message).to receive(:ack!)
+      expect(subscription.main_callback(message)).to eql 'success!'
+    end
+
+
     it "acknowledges a message and logs an error if there's no callback registered for it" do
       pubsub = instance_double('PubsubDouble')
       expect(pubsub).to receive(:get_subscription).with('test_subscription', project: 'test-project-id')


### PR DESCRIPTION
The trouble was moving the with_indifferent_access to a single place
and forgetting about this particular usage.