### PR TITLE
Fix several issues with logger & error reporting

### DIFF
--- a/lib/carto/common/base_command.rb
+++ b/lib/carto/common/base_command.rb
@@ -24,7 +24,13 @@ module Carto
             before_run_hooks
             run_command
           rescue StandardError => e
-            logger.error(log_context.merge(message: 'Command failed', exception: e))
+            logger.error(
+              log_context.merge(
+                message: 'Command failed',
+                exception: e,
+                rollbar: false # Don't report to Rollbar twice, as we're re-raising the exception afterwards
+              )
+            )
             raise e
           ensure
             after_run_hooks

--- a/lib/carto/common/logger_formatter.rb
+++ b/lib/carto/common/logger_formatter.rb
@@ -32,6 +32,8 @@ module Carto
           message_hash[:message] = exception.message if message_hash[:message].blank?
         end
 
+        serialize_message_hash_values!(message_hash)
+
         replace_key(message_hash, :current_user, :'cdb-user')
         replace_key(message_hash, :message, :event_message)
 
@@ -39,6 +41,16 @@ module Carto
       end
 
       private
+
+      def serialize_message_hash_values!(message_hash)
+        message_hash.each do |key, value|
+          if user?(value)
+            message_hash[key] = value.username
+          elsif organization?(value)
+            message_hash[key] = value.name
+          end
+        end
+      end
 
       def levelname(severity)
         return 'info' if severity.blank?
@@ -63,6 +75,17 @@ module Carto
           end
         end
       end
+
+      def user?(object)
+        (defined?(::User) && object.is_a?(::User)) ||
+          (defined?(::Carto::User) && object.is_a?(::Carto::User))
+      end
+
+      def organization?(object)
+        (defined?(::Organization) && object.is_a?(::Organization)) ||
+          (defined?(::Carto::Organization) && object.is_a?(::Carto::Organization))
+      end
+
     end
   end
 end

--- a/lib/carto/common/message_broker.rb
+++ b/lib/carto/common/message_broker.rb
@@ -248,11 +248,7 @@ module Carto
               ret
             rescue StandardError => e
               logger.error(message: 'Error in message processing callback',
-                           exception: {
-                             class: e.class.name,
-                             message: e.message,
-                             backtrace_hint: e.backtrace&.take(5)
-                           },
+                           exception: e,
                            subscription_name: @subscription_name,
                            message_type: message_type)
               # Make the message available for redelivery

--- a/lib/carto/common/message_broker.rb
+++ b/lib/carto/common/message_broker.rb
@@ -234,10 +234,11 @@ module Carto
           attributes = received_message.attributes
           message_type = attributes['event'].to_sym
           message_callback = @callbacks[message_type]
+          payload = JSON.parse(received_message.data)
+          request_id = payload.delete('request_id')
+
           if message_callback
             begin
-              payload = JSON.parse(received_message.data)
-              request_id = payload.delete('request_id')
               message = Message.new(
                 payload: payload,
                 request_id: request_id,
@@ -257,7 +258,8 @@ module Carto
           else
             logger.error(message: 'No callback registered for message',
                          subscription_name: @subscription_name,
-                         message_type: message_type)
+                         message_type: message_type,
+                         request_id: request_id)
             received_message.ack!
           end
         end

--- a/lib/carto/common/message_broker.rb
+++ b/lib/carto/common/message_broker.rb
@@ -269,6 +269,7 @@ module Carto
           raise NotFound, "Subscription #{@subscription_name} does not exist" if @subscription.blank?
 
           @subscriber = @subscription.listen(options, &method(:main_callback))
+          @subscriber.on_error { |error| logger.error(error) }
           @subscriber.start
         end
 

--- a/spec/carto/common/action_mailer_log_subscriber_spec.rb
+++ b/spec/carto/common/action_mailer_log_subscriber_spec.rb
@@ -1,31 +1,6 @@
 require 'spec_helper'
 require './lib/carto/common/action_mailer_log_subscriber'
 
-# Mocks CartoDB & Central users as they don't exist in the context of this gem
-class User
-
-  attr_accessor :email, :username
-
-  @users = []
-
-  class << self
-
-    attr_reader :users
-
-  end
-
-  def self.find_by(params = {})
-    @users.select { |user| user.email == params[:email] }.first
-  end
-
-  def initialize(params = {})
-    self.email = params[:email]
-    self.username = params[:username]
-    User.users << self
-  end
-
-end
-
 RSpec.describe 'Carto::Common::ActionMailerLogSubscriber' do
   subject { Carto::Common::ActionMailerLogSubscriber.new }
 
@@ -33,7 +8,7 @@ RSpec.describe 'Carto::Common::ActionMailerLogSubscriber' do
   let(:event_payload) { {} }
   let(:event) { ActiveSupport::Notifications::Event.new(event_name, Time.now, Time.now + 1.second, 1, event_payload) }
 
-  context '#process' do
+  describe '#process' do
     let(:event_name) { 'process.action_mailer' }
     let(:event_payload) { { mailer: 'DummyMailer', action: 'dummy_mailer_method' } }
 
@@ -49,7 +24,7 @@ RSpec.describe 'Carto::Common::ActionMailerLogSubscriber' do
     end
   end
 
-  context '#deliver' do
+  describe '#deliver' do
     let(:user) { User.new(email: 'somebody@example.com') }
     let(:event_name) { 'deliver.action_mailer' }
     let(:receiver_addresses) { [user.email] }

--- a/spec/carto/common/logger_formatter_spec.rb
+++ b/spec/carto/common/logger_formatter_spec.rb
@@ -104,6 +104,46 @@ RSpec.describe Carto::Common::LoggerFormatter do
     end
   end
 
+  context 'when serializing ::User objects' do
+    let(:user) { User.create(username: 'foobar') }
+    let(:output) { subject.call(severity, time, progname, { some_key: user }) }
+    let(:parsed_output) { JSON.parse(output) }
+
+    it 'outputs the username' do
+      expect(parsed_output['some_key']).to eq('foobar')
+    end
+  end
+
+  context 'when serializing ::Carto::User objects' do
+    let(:user) { Carto::User.create(username: 'foobar') }
+    let(:output) { subject.call(severity, time, progname, { some_key: user }) }
+    let(:parsed_output) { JSON.parse(output) }
+
+    it 'outputs the username' do
+      expect(parsed_output['some_key']).to eq('foobar')
+    end
+  end
+
+  context 'when serializing ::Organization objects' do
+    let(:organization) { Organization.create(name: 'foobar') }
+    let(:output) { subject.call(severity, time, progname, { some_key: organization }) }
+    let(:parsed_output) { JSON.parse(output) }
+
+    it 'outputs the organization name' do
+      expect(parsed_output['some_key']).to eq('foobar')
+    end
+  end
+
+  context 'when serializing ::Carto::Organization objects' do
+    let(:organization) { Carto::Organization.create(name: 'foobar') }
+    let(:output) { subject.call(severity, time, progname, { some_key: organization }) }
+    let(:parsed_output) { JSON.parse(output) }
+
+    it 'outputs the organization name' do
+      expect(parsed_output['some_key']).to eq('foobar')
+    end
+  end
+
   it 'renames current_user to cdb-user' do
     output = subject.call(severity, time, progname, { message: 'Something!', current_user: 'peter' })
     parsed_output = JSON.parse(output)

--- a/spec/carto/common/logger_formatter_spec.rb
+++ b/spec/carto/common/logger_formatter_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Carto::Common::LoggerFormatter do
   let(:severity) { 'INFO' }
   let(:time) { Time.now }
   let(:progname) {}
+  let(:parsed_output) { JSON.parse(output) }
 
   context 'message format' do
     it 'accepts blank message' do
@@ -85,7 +86,6 @@ RSpec.describe Carto::Common::LoggerFormatter do
   context 'when serializing exceptions' do
     let(:exception) { StandardError.new('Error body') }
     let(:output) { subject.call(severity, time, progname, { exception: exception }) }
-    let(:parsed_output) { JSON.parse(output) }
 
     it 'outputs the exception class' do
       expect(parsed_output['exception']['class']).to eq('StandardError')
@@ -107,7 +107,6 @@ RSpec.describe Carto::Common::LoggerFormatter do
   context 'when serializing ::User objects' do
     let(:user) { User.create(username: 'foobar') }
     let(:output) { subject.call(severity, time, progname, { some_key: user }) }
-    let(:parsed_output) { JSON.parse(output) }
 
     it 'outputs the username' do
       expect(parsed_output['some_key']).to eq('foobar')
@@ -117,7 +116,6 @@ RSpec.describe Carto::Common::LoggerFormatter do
   context 'when serializing ::Carto::User objects' do
     let(:user) { Carto::User.create(username: 'foobar') }
     let(:output) { subject.call(severity, time, progname, { some_key: user }) }
-    let(:parsed_output) { JSON.parse(output) }
 
     it 'outputs the username' do
       expect(parsed_output['some_key']).to eq('foobar')
@@ -127,7 +125,6 @@ RSpec.describe Carto::Common::LoggerFormatter do
   context 'when serializing ::Organization objects' do
     let(:organization) { Organization.create(name: 'foobar') }
     let(:output) { subject.call(severity, time, progname, { some_key: organization }) }
-    let(:parsed_output) { JSON.parse(output) }
 
     it 'outputs the organization name' do
       expect(parsed_output['some_key']).to eq('foobar')
@@ -137,7 +134,6 @@ RSpec.describe Carto::Common::LoggerFormatter do
   context 'when serializing ::Carto::Organization objects' do
     let(:organization) { Carto::Organization.create(name: 'foobar') }
     let(:output) { subject.call(severity, time, progname, { some_key: organization }) }
-    let(:parsed_output) { JSON.parse(output) }
 
     it 'outputs the organization name' do
       expect(parsed_output['some_key']).to eq('foobar')

--- a/spec/carto/common/message_broker_spec.rb
+++ b/spec/carto/common/message_broker_spec.rb
@@ -82,14 +82,8 @@ RSpec.describe Carto::Common::MessageBroker do
     end
 
     it 'propagates the specified logger to the subscriptions' do
-      gcloud_subscriber = instance_double(Google::Cloud::PubSub::Subscriber)
-      allow(gcloud_subscriber).to receive(:start)
-
-      gcloud_subscription = instance_double(Google::Cloud::PubSub::Subscription)
-      allow(gcloud_subscription).to receive(:listen).and_return(gcloud_subscriber)
-
       pubsub = instance_double('PubsubDouble')
-      allow(pubsub).to receive(:get_subscription).and_return(gcloud_subscription)
+      allow(pubsub).to receive(:get_subscription).and_return(PubSubSubscriptionDouble.new)
 
       config = instance_double('Config', project_id: 'test-project-id')
       allow(Carto::Common::MessageBroker::Config).to receive(:instance).and_return(config)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,20 @@
+require 'byebug'
 require "bundler/setup"
 require "carto/common/encryption_service"
 require 'carto/common/logger'
 require "carto/common/logger_formatter"
 require 'google/cloud/pubsub'
+require './spec/support/application_record_mock'
+
+# Mocks CartoDB & Central models as they don't exist in the context of this gem
+class User < ApplicationRecordMock; end
+class Organization < ApplicationRecordMock; end
+module Carto
+
+  class User < ApplicationRecordMock; end
+  class Organization < ApplicationRecordMock; end
+
+end
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,4 +59,24 @@ class PubsubMessageDouble < Google::Cloud::Pubsub::Message
   end
 
 end
+
+class PubSubSubscriberDouble < Google::Cloud::PubSub::Subscriber
+
+  def initialize; end
+
+  def start; end
+
+  def on_error; end
+
+end
+
+class PubSubSubscriptionDouble < Google::Cloud::PubSub::Subscription
+
+  def initialize; end
+
+  def listen(*)
+    PubSubSubscriberDouble.new
+  end
+
+end
 # rubocop:enable Lint/UselessMethodDefinition

--- a/spec/support/application_record_mock.rb
+++ b/spec/support/application_record_mock.rb
@@ -1,0 +1,26 @@
+class ApplicationRecordMock < OpenStruct
+
+  @records = []
+
+  class << self
+
+    attr_accessor :records
+
+  end
+
+  def self.create(params = {})
+    new(params)
+  end
+
+  def self.find_by(params = {})
+    ApplicationRecordMock.records.find do |record|
+      params.all? { |key, value| record[key] == value }
+    end
+  end
+
+  def initialize(params = {})
+    super(params)
+    ApplicationRecordMock.records << self
+  end
+
+end


### PR DESCRIPTION
# What does this PR do?

## Serialize User and Organization objects in cartodb-common Carto::Common::LoggerFormatter

Ticket: https://app.clubhouse.io/cartoteam/story/129371/serialize-user-and-organization-objects-in-cartodb-common-carto-common-loggerformatter

**Staging acceptance** ✅ 

```ruby
# [stag] ubuntu@central-front-2:~/www/production.cartodb.com/current$ bundle exec rails c staging
Rails.logger.info(message: 'Amiedes serialization test 2', foobar: User.first)
Rails.logger.info(message: 'Amiedes serialization test 3', barbaz: Organization.first)
```

from `staging.log`:

```json
{"foobar":"sconde-carto","timestamp":"2021-02-24T15:24:57.729+00:00","levelname":"info","cdb-user":null,"event_message":"Amiedes serialization test 2"}
{"barbaz":"rt-aena","timestamp":"2021-02-24T15:26:18.660+00:00","levelname":"info","cdb-user":null,"event_message":"Amiedes serialization test 3"}
```

## Rollbar Empty message error

Ticket: https://app.clubhouse.io/cartoteam/story/132853/rollbar-empty-message-error

**Staging acceptance** ✅ 

This is a bit trickier because I have to show that [something that was happening before does not happen anymore](https://app.clubhouse.io/cartoteam/story/132853/rollbar-empty-message-error#activity-138584).

By manually publishing an event which previously triggered the `Empty message` error, now you can see the inner error is not masked:

```bash
ssh ded-dynamic-zdeohun.ep.carto-staging.com
# ...
RAILS_ENV=staging \
COVERBAND_DISABLE_AUTO_START=true \
MESSAGE_BROKER_PUBSUB_PROJECT_ID=cartodb-on-gcp-staging \
MESSAGE_BROKER_CENTRAL_SUBSCRIPTION_NAME=central_dedicated_ded-dynamic-zdeohun.ep.carto-staging.com \
MESSAGE_BROKER_PUBLISHER_VALIDATION_TOKEN=ded-dynamic-zdeohun \
  bundle exec rails c
```

```ruby
logger = Carto::Common::Logger.new($stdout)
message_broker = Carto::Common::MessageBroker.new(logger: logger)
notifications_topic = message_broker.get_topic(:cartodb_central)
notifications_topic.publish(:organization_created, { id: 'fake-id-2', name: 'fake-name-2' })
```

The Rollbar occurrence which was created: https://rollbar.com/carto/CartoDB-Central/items/20805/?item_page=0&item_count=100&#instances

## Broker: add on_error hook with error trace

Ticket: https://app.clubhouse.io/cartoteam/story/135296/broker-add-on-error-hook-with-error-trace

**Staging acceptance** ✅ 

Let's publish a buggy message to central (no JSON format):

```
[stag] ubuntu@rui04:~$ gcloud pubsub topics publish \
>   projects/cartodb-on-gcp-staging/topics/broker_cartodb_central \
>   --message="Amiedes error test 1" \
>   --attribute=FOO=BAR
messageIds:
- '2055066262355749'
```

And we get the corresponding Rollbar error: https://rollbar.com/carto/CartoDB-Central/items/20804/occurrences/153546453432/

## Adds the `request_id` to the "No callback registered for message" error

Ticket: https://app.clubhouse.io/cartoteam/story/130725/add-the-request-id-to-the-no-callback-registered-for-message-error

**Staging acceptance** ✅ 

Publish a fake message which will trigger the `No callback registered for message` in the dedicated server subscriber:

```ruby
message_broker = Carto::Common::MessageBroker.new(logger: Rails.logger)
cloud = Cloud.find_by(ip: 'ded-dynamic-zdeohun.ep.carto-staging.com')
topic = message_broker.get_topic(cloud.topic_name)

Carto::Common::CurrentRequest.with_request_id('amiedes-request-id-test-2') do
  topic.publish(:amiedes_request_id_test_2, { foo: 'bar' })
end
```

From `ded-dynamic-zdeohun.ep.carto-staging.com` subscriber logs:

```json
{"subscription_name":"broker_central_dedicated_ded-dynamic-zdeohun.ep.carto-staging.com","message_type":"amiedes_request_id_test_2","request_id":"amiedes-request-id-test-2","timestamp":"2021-02-24T15:47:27.808+00:00","levelname":"error","cdb-user":null,"event_message":"No callback registered for message"}
```

You can see the fake request ID we put was propagated from the publisher to the subscriber.